### PR TITLE
Include Tester submodule and Makefile targets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "submodules/LIB"]
 	path = submodules/LIB
 	url = git@github.com:IObundle/iob-lib.git
+[submodule "submodules/TESTER"]
+	path = submodules/TESTER
+	url = git@github.com:arturum1/iob-soc.git
+	branch = tester

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,4 @@
 	url = git@github.com:IObundle/iob-lib.git
 [submodule "submodules/TESTER"]
 	path = submodules/TESTER
-	url = git@github.com:arturum1/iob-soc.git
-	branch = tester
+	url = git@github.com:arturum1/iob-soc-tester.git

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,18 @@ sim-clean:
 	make -C $(SIM_DIR) clean
 
 #
+# TESTER
+#
+tester-sim:
+	make -C $(TESTER_DIR) sim CORE_UT=TIMER
+
+tester-fpga-build:
+	make -C $(TESTER_DIR) fpga-build CORE_UT=TIMER
+
+#
 # CLEAN ALL
 # 
 
 clean: sim-clean
 
-.PHONY: corename sim sim-clean clean
+.PHONY: corename sim sim-clean tester-sim tester-fpga-build clean


### PR DESCRIPTION
This PR includes a TESTER submodule created in https://github.com/IObundle/iob-soc-tester/pull/3 _(note that PR is for a private repository, a public version of the same changes can be found in '[tester](https://github.com/arturum1/iob-soc/tree/tester)' branch of my fork of iob-soc)_.

This PR also includes makefile targets, allowing to test the iob-timer core by running:
`make tester-sim` and `make tester-fpga-build`

Since the TESTER submodule is in a private repository, maybe we should merge this PR in a **new** branch.