### PR TITLE
feat(mkregs): update LIB, ignore cpu addr 2 LBS

### DIFF
--- a/hardware/include/inst.vh
+++ b/hardware/include/inst.vh
@@ -8,7 +8,7 @@
 
       //cpu interface
       .valid(slaves_req[`valid(`TIMER)]),
-      .address(slaves_req[`address(`TIMER,`TIMER_ADDR_W)]),
+      .address(slaves_req[`address(`TIMER,`TIMER_ADDR_W+2)-2]),
       .wdata(slaves_req[`wdata(`TIMER)]),
       .wstrb(slaves_req[`wstrb(`TIMER)]),
       .rdata(slaves_resp[`rdata(`TIMER)]),


### PR DESCRIPTION
- update LIB submodule
- ignore 2 least significant bits from cpu address
- see IObundle/iob-lib#103