### PR TITLE
Add TOP_MODULE in config.mk

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,3 +1,5 @@
+TOP_MODULE=iob_timer
+
 DATA_W=32
 
 #PATHS


### PR DESCRIPTION
This variable is required by iob-soc/system python build scripts.
It will also be required the `info.mk` file when using iob-soc/build-lib.