### PR TITLE
Fix TIMER_ADDR_W

### DIFF
--- a/hardware/include/iob_timer.vh
+++ b/hardware/include/iob_timer.vh
@@ -1,4 +1,4 @@
-`define TIMER_ADDR_W 3
+`define TIMER_ADDR_W 2
 `define TIMER_WDATA_W 1
 `ifndef DATA_W
  `define DATA_W 32


### PR DESCRIPTION
Timer registers from mkregs.conf only need 2 addresses, therefore ADDR_W should be 2.
Without this, there would be a mismatch with ADDR_W generated by mkregs.py