### PR TITLE
Update LIB and iob_timer_setup.py accordingly; Remove meta variable.

### DIFF
--- a/iob_timer_setup.py
+++ b/iob_timer_setup.py
@@ -4,14 +4,12 @@ import os, sys
 sys.path.insert(0, os.getcwd()+'/submodules/LIB/scripts')
 import setup
 
-meta = \
-{
-'name':'iob_timer',
-'version':'V0.10',
-'flows':'sim',
-'setup_dir':os.path.dirname(__file__)}
-meta['build_dir']=f"../{meta['name']+'_'+meta['version']}"
-meta['submodules'] = {
+name='iob_timer'
+version='V0.10'
+flows='sim emb'
+setup_dir=os.path.dirname(__file__)
+build_dir=f"../{name}_{version}"
+submodules = {
     'hw_setup': {
         'headers' : [ 'iob_s_port', 'iob_s_portmap' ],
         'modules': [ 'iob_reg.v', 'iob_reg_e.v', 'iob_counter', 'iob_reg_r.v' ]

--- a/iob_timer_setup.py
+++ b/iob_timer_setup.py
@@ -7,8 +7,9 @@ import setup
 name='iob_timer'
 version='V0.10'
 flows='sim emb'
-setup_dir=os.path.dirname(__file__)
-build_dir=f"../{name}_{version}"
+if setup.is_top_module(sys.modules[__name__]):
+    setup_dir=os.path.dirname(__file__)
+    build_dir=f"../{name}_{version}"
 submodules = {
     'hw_setup': {
         'headers' : [ 'iob_s_port', 'iob_s_portmap' ],


### PR DESCRIPTION
- Remove outdated meta variable
- Update iob_timer_setup.py according to new LIB. The setup and build directories should only be set if the module is not being imported by another (if the module is not the top module).