### PR TITLE
Fix timer delaying after some time running

### DIFF
--- a/software/iob-timer.c
+++ b/software/iob-timer.c
@@ -12,18 +12,17 @@ void timer_init(int base_address) {
     IOB_TIMER_SET_ENABLE(1);
 }
 
-unsigned long long timer_get_count() {
+uint64_t timer_get_count() {
 
-    unsigned long long timer_total;
-    unsigned int timer_high, timer_low;
+    uint64_t timer_total, timer_high, timer_low;
 
     // sample timer
     IOB_TIMER_SET_SAMPLE(1);
     IOB_TIMER_SET_SAMPLE(0);
 
     // get count
-    timer_high = (unsigned int) IOB_TIMER_GET_DATA_HIGH();
-    timer_low = (unsigned int) IOB_TIMER_GET_DATA_LOW();
+    timer_high = IOB_TIMER_GET_DATA_HIGH();
+    timer_low = IOB_TIMER_GET_DATA_LOW();
     timer_total = timer_high;
     timer_total <<= 32;
     timer_total |= timer_low;
@@ -35,31 +34,31 @@ unsigned long long timer_get_count() {
 // timer_time_tu(1):        time in seconds
 // timer_time_tu(1000):     time in milliseconds
 // timer_time_tu(1000000):  time in microseconds
-unsigned int timer_time_tu(int sample_rate) {
+uint64_t timer_time_tu(uint64_t sample_rate) {
 
-  //get time count
-  unsigned long long timer_total = timer_get_count();
+    //get time count
+    uint64_t timer_total = timer_get_count();
 
-  //number of clocks per time unit
-  float ticks_per_tu = ( (float) FREQ)/sample_rate;
- 
-  //time in us
-  float time_tu = timer_total / ticks_per_tu;
- 
-  return (unsigned int) time_tu;
+    //number of clocks per time unit
+    uint64_t ticks_per_tu = (FREQ)/sample_rate;
+
+    //time in us
+    uint64_t time_tu = timer_total / ticks_per_tu;
+
+    return time_tu;
 }
 
 //get time in us
-unsigned int timer_time_us() {
-  return timer_time_tu(1000000);
+uint64_t timer_time_us() {
+    return timer_time_tu(1000000);
 }
 
 //get time in ms
-unsigned int timer_time_ms() {
-  return timer_time_tu(1000);
+uint64_t timer_time_ms() {
+    return timer_time_tu(1000);
 }
 
 //get time in s
-unsigned int timer_time_s() {
-  return timer_time_tu(1);
+uint64_t timer_time_s() {
+    return timer_time_tu(1);
 }

--- a/software/iob-timer.h
+++ b/software/iob-timer.h
@@ -6,8 +6,8 @@
 void timer_reset();
 void timer_init( int base_address);	
 
-unsigned long long timer_get_count();
-unsigned int timer_time_tu(int sample_rate);
-unsigned int timer_time_us();
-unsigned int timer_time_ms();
-unsigned int timer_time_s();
+uint64_t timer_get_count();
+uint64_t timer_time_tu(uint64_t sample_rate);
+uint64_t timer_time_us();
+uint64_t timer_time_ms();
+uint64_t timer_time_s();


### PR DESCRIPTION
After a day or 2 of running, the timer would start to delay too much. Possibly because of conversions between different types of variables. So I've changed all types to uint64_t to have the same size as the total of what comes from the IOB_TIMER_GET_DATA_HIGH()/LOW() functions.